### PR TITLE
added forms in internal orders

### DIFF
--- a/src/components/controlled-file-upload/index.tsx
+++ b/src/components/controlled-file-upload/index.tsx
@@ -1,0 +1,56 @@
+import { Controller, type Control, type FieldError, type FieldValues, type Path } from 'react-hook-form';
+import { Input } from '@/components/ui/input';
+import AdminDefaultImage from '../admin-default-image';
+
+interface ControlledFileUploadProps<T extends FieldValues> {
+	name: Path<T>;
+	control: Control<T>;
+	label?: string;
+	accept?: string;
+	error?: FieldError | string;
+}
+
+const ControlledFileUpload = <T extends FieldValues>({
+	name,
+	control,
+	label,
+	accept = '',
+	error,
+}: ControlledFileUploadProps<T>) => {
+	return (
+		<div className="w-full text-xs">
+			<AdminDefaultImage height={50} width={50} className="my-3" />
+			{label && (
+				<label htmlFor={name} className="block mb-1">
+					{label}
+				</label>
+			)}
+
+			<Controller
+				name={name}
+				control={control}
+				render={({ field: { onChange, ref } }) => (
+					<Input
+						type="file"
+						id={name}
+						ref={ref}
+						accept={accept}
+						onChange={(e) => {
+							const file = e.target.files?.[0] ?? null;
+							onChange(file);
+						}}
+						className="block w-full h-7 mt-2 p-0 text-xs text-gray-900  border-none rounded-none
+                         file:mr-1 file:py-1 file:px-2 file:rounded-none
+                         file:border file:border-gray-300
+                         file:text-xs file:font-normal
+                       file:bg-gray-100 file:text-gray-700"
+					/>
+				)}
+			/>
+
+			{error && <p className="text-xs text-red-500 mt-1">{typeof error === 'string' ? error : error.message}</p>}
+		</div>
+	);
+};
+
+export default ControlledFileUpload;

--- a/src/components/custom-form-input/index.tsx
+++ b/src/components/custom-form-input/index.tsx
@@ -9,7 +9,7 @@ type InputType = 'text' | 'number' | 'email' | 'textarea';
 interface CustomFormInputProps<T extends FieldValues> {
 	control: Control<T>;
 	name: Path<T>;
-	label: string;
+	label?: string;
 	type?: InputType;
 	className?: string;
 	labelClassName?: string;

--- a/src/components/custom-textarea/index.tsx
+++ b/src/components/custom-textarea/index.tsx
@@ -11,7 +11,7 @@ const CustomTextarea = ({
 		id={id}
 		name={name}
 		className={cn(
-			'w-full mt-3 rounded-[2px] border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground placeholder:text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+			'w-full mt-3 rounded-[2px] border border-input bg-background px-3 py-2 text-[12px] ring-offset-background placeholder:text-muted-foreground placeholder:text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
 			className
 		)}
 		rows={rows}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -64,3 +64,4 @@ export { default as TextLink } from './text-link';
 export { default as TableActionButtons } from './table-action-buttons';
 export { default as ControlledDateInputField } from './controlled-date-input-field';
 export { default as ControlledRadioGroup } from './controlled-radio-group';
+export { default as ControlledFileUpload } from './controlled-file-upload';

--- a/src/data/side-navbar-content/index.ts
+++ b/src/data/side-navbar-content/index.ts
@@ -299,22 +299,25 @@ const side_nav_links = [
 				path_url: '/pious_group/parish_council_members',
 				label: 'Parish Council Members',
 				icon: 'BookText',
-				tabs: [{ label: 'COUNCIL DETAILS' }, { label: 'View' }, { label: 'add/change' }],
+				tabs: [{ label: 'COUNCIL DETAILS' }, { label: 'view' }, { label: 'add' }],
 			},
 			{
 				path_url: '/pious_group/religious_people_parish',
 				label: 'Religious People in Parish',
 				icon: 'BookText',
+				tabs: [{ label: 'view' }, { label: 'add' }],
 			},
 			{
 				path_url: '/pious_group/priest_nun_parish',
 				label: 'Sons and Daughters of the Soil',
 				icon: 'BookText',
+				tabs: [{ label: 'view' }, { label: 'add' }],
 			},
 			{
 				path_url: '/pious_group/family_members',
 				label: 'Members in Families',
 				icon: 'BookText',
+				tabs: [{ label: 'view' }, { label: 'add' }],
 			},
 			{
 				path_url: '/pious_group/families',
@@ -338,11 +341,13 @@ const side_nav_links = [
 				path_url: '/pious_group/anbiams',
 				label: 'Anbiam',
 				icon: 'BookText',
+				tabs: [{ label: 'view' }, { label: 'add' }],
 			},
 			{
 				path_url: '/pious_group/associations_club',
 				label: 'Associations & Club',
 				icon: 'BookText',
+				tabs: [{ label: 'view' }, { label: 'add' }],
 			},
 			{
 				path_url: '/pious_group/anbiam_incharge',

--- a/src/features/pious-group/components/forms-container/index.tsx
+++ b/src/features/pious-group/components/forms-container/index.tsx
@@ -1,0 +1,54 @@
+import { useRouteName } from '@/utils/getRouteName';
+import {
+	AnbiamInchargeForm,
+	AnbiamsForm,
+	ParishCouncilMembersForm,
+	PriestNunParishForm,
+	ReligiousParishCouncilMembersForm,
+} from '../../forms';
+
+const RenderFormsContainer = () => {
+	const type = useRouteName('type');
+
+	const renderForms = [
+		{
+			pageName: 'parish_council_members',
+			component: <ParishCouncilMembersForm />,
+		},
+		{
+			pageName: 'religious_people_parish',
+			component: <ReligiousParishCouncilMembersForm />,
+		},
+		{
+			pageName: 'priest_nun_parish',
+			component: <PriestNunParishForm />,
+		},
+		{
+			pageName: 'family_members',
+			component: <h1>Family Members Form will be added</h1>,
+		},
+		{
+			pageName: 'families',
+			component: <h1>Families Form will be added</h1>,
+		},
+		{
+			pageName: 'anbiams',
+			component: <AnbiamsForm />,
+		},
+		{
+			pageName: 'associations_club',
+			component: <h1>associations_club form will bee added</h1>,
+		},
+		{
+			pageName: 'anbiam_incharge',
+			component: <AnbiamInchargeForm />,
+		},
+		{
+			pageName: 'associations_incharge',
+			component: <h1>associations_incharge form will bee added</h1>,
+		},
+	];
+	return renderForms.find((form) => form.pageName === type)?.component || <h1>forms will be added</h1>;
+};
+
+export default RenderFormsContainer;

--- a/src/features/pious-group/components/index.ts
+++ b/src/features/pious-group/components/index.ts
@@ -2,3 +2,4 @@ export { default as RenderPiousGroupOverviewContainer } from './render-pious-gro
 export { default as RenderPiousGroupTables } from './render-pious-group-tables';
 export { default as CouncilMemberDetailsContainer } from './generic-religious-people-details-container';
 export { default as GenericMembersInFamilesOverviewContainer } from './generic-members-in-familes-overview-container';
+export { default as FormsContainer } from './forms-container';

--- a/src/features/pious-group/forms/anbiam-incharge-form/index.tsx
+++ b/src/features/pious-group/forms/anbiam-incharge-form/index.tsx
@@ -1,0 +1,126 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { SingleSelectDropdown, FormButton, CustomFormInput, ControlledDateInputField } from '@/components';
+import { positionsOptions, subStationOptions } from '@/forms-options-data';
+import { anbiamsInchargeSchema, type AnbiamInchargeType } from '../../validation';
+
+const AnbiamInchargeForm = () => {
+	const {
+		control,
+		handleSubmit,
+		formState: { errors },
+	} = useForm<AnbiamInchargeType>({
+		resolver: zodResolver(anbiamsInchargeSchema),
+		defaultValues: {},
+	});
+
+	const onSubmit = (data: AnbiamInchargeType) => {
+		console.warn('Submitted Anbiam Incharge Data:', data);
+	};
+
+	return (
+		<form onSubmit={handleSubmit(onSubmit)} className="space-y-4 text-sm my-6">
+			<div className="flex flex-wrap w-full gap-4">
+				<div className="flex-1 w-full p-5 space-y-5 border border-gray-300 rounded-md">
+					<SingleSelectDropdown
+						control={control}
+						label="Main-Station / Sub-Station"
+						options={subStationOptions}
+						placeholder="Select Sub-Station"
+						name="subStationName"
+						error={errors.subStationName?.message}
+					/>
+					<SingleSelectDropdown
+						control={control}
+						label="Select the Anbiam"
+						options={[]}
+						placeholder="Select Anbiam"
+						name="selectedAnbiam"
+						error={errors.selectedAnbiam?.message}
+					/>
+					<CustomFormInput
+						control={control}
+						name="shortForm"
+						label="Short Form"
+						error={errors.shortForm?.message}
+						placeholder="Enter Short Form"
+					/>
+					<ControlledDateInputField
+						label="General Election Conducted On"
+						name="electionConductedOn"
+						control={control}
+						placeholder="dd/mm/yyyy"
+						error={errors.electionConductedOn?.message}
+						type="date"
+					/>
+				</div>
+
+				<div className="flex-1 w-full p-5 space-y-5 border border-gray-300 rounded-md">
+					<SingleSelectDropdown
+						name="position"
+						control={control}
+						label="Position"
+						options={positionsOptions}
+						error={errors.position?.message}
+					/>
+					<SingleSelectDropdown
+						name="electedStatus"
+						control={control}
+						label="Elected Status"
+						options={[
+							{ label: 'Regular', value: 'regular' },
+							{ label: 'Intermediate', value: 'intermediate' },
+						]}
+						error={errors.electedStatus?.message}
+					/>
+					<CustomFormInput
+						control={control}
+						name="presidentName"
+						label="Name of President for Anbiam"
+						error={errors.presidentName?.message}
+						placeholder="Enter President's Name"
+					/>
+					<CustomFormInput
+						control={control}
+						name="mobileNumber1"
+						label="Mobile Number - 1"
+						error={errors.mobileNumber1?.message}
+						placeholder="Enter Mobile Number 1"
+					/>
+					<CustomFormInput
+						control={control}
+						name="mobileNumber2"
+						label="Mobile Number - 2 (optional)"
+						error={errors.mobileNumber2?.message}
+						placeholder="Enter Mobile Number 2"
+					/>
+				</div>
+
+				<div className="flex-1 w-full p-5 space-y-5 border border-gray-300 rounded-md">
+					<ControlledDateInputField
+						label="Elected Date"
+						name="electedDate"
+						control={control}
+						placeholder="dd/mm/yyyy"
+						error={errors.electedDate?.message}
+						type="date"
+					/>
+					<ControlledDateInputField
+						label="Period End On"
+						name="periodEndOn"
+						control={control}
+						placeholder="dd/mm/yyyy"
+						error={errors.periodEndOn?.message}
+						type="date"
+					/>
+				</div>
+			</div>
+
+			<div className="flex justify-center w-full">
+				<FormButton type="submit" label="Submit" />
+			</div>
+		</form>
+	);
+};
+
+export default AnbiamInchargeForm;

--- a/src/features/pious-group/forms/anbiams-form/index.tsx
+++ b/src/features/pious-group/forms/anbiams-form/index.tsx
@@ -1,0 +1,109 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+	SingleSelectDropdown,
+	FormButton,
+	CustomFormInput,
+	ControlledDateInputField,
+	ControlledRadioGroup,
+} from '@/components';
+import { subStationOptions } from '@/forms-options-data';
+import { anbiamsSchema, type AnbiamsType } from '../../validation';
+
+const AnbiamsForm = () => {
+	const {
+		control,
+		handleSubmit,
+		formState: { errors },
+	} = useForm<AnbiamsType>({
+		resolver: zodResolver(anbiamsSchema),
+		defaultValues: {},
+	});
+
+	const onSubmit = (data: AnbiamsType) => {
+		console.warn('Submitted Anbiam Data:', data);
+	};
+
+	return (
+		<form onSubmit={handleSubmit(onSubmit)} className="space-y-4 text-sm my-6">
+			<div className="flex flex-wrap w-full gap-4">
+				<div className="flex-1 w-full p-5 space-y-5 border border-gray-300 rounded-md">
+					<CustomFormInput
+						control={control}
+						name="parishName"
+						label="Parish Name"
+						error={errors.parishName?.message}
+						placeholder="Enter Parish Name"
+					/>
+					<SingleSelectDropdown
+						control={control}
+						label="Select the Main-Station / Sub-Station"
+						options={subStationOptions}
+						placeholder="Select Sub-Station"
+						name="subStationName"
+						error={errors.subStationName?.message}
+					/>
+					<CustomFormInput
+						control={control}
+						name="anbiamName"
+						label="Name of the Anbiam"
+						error={errors.anbiamName?.message}
+						placeholder="Enter Anbiam Name"
+					/>
+				</div>
+
+				<div className="flex-1 w-full p-5 space-y-5 border border-gray-300 rounded-md">
+					<CustomFormInput
+						control={control}
+						name="anbiamShortForm"
+						label="Anbiam Short Form"
+						error={errors.anbiamShortForm?.message}
+						placeholder="Enter Short Form"
+					/>
+					<ControlledDateInputField
+						label="Elected On"
+						name="electedOn"
+						control={control}
+						placeholder="dd/mm/yyyy"
+						error={errors.electedOn?.message}
+						type="date"
+					/>
+					<CustomFormInput
+						control={control}
+						name="periodYears"
+						label="Period of (How many years)"
+						error={errors.periodYears?.message}
+						placeholder="Enter duration in years"
+					/>
+					<ControlledRadioGroup
+						label="Do you want to extend the period?"
+						name="extendPeriod"
+						control={control}
+						options={[
+							{ label: 'Yes', value: 'yes' },
+							{ label: 'No', value: 'no' },
+						]}
+						error={errors.extendPeriod?.message}
+					/>
+				</div>
+
+				<div className="flex-1 w-full p-5 space-y-5 border border-gray-300 rounded-md">
+					<ControlledDateInputField
+						label="Period End On"
+						name="periodEndOn"
+						control={control}
+						placeholder="dd/mm/yyyy"
+						error={errors.periodEndOn?.message}
+						type="date"
+					/>
+				</div>
+			</div>
+
+			<div className="flex justify-center w-full">
+				<FormButton type="submit" label="Submit" />
+			</div>
+		</form>
+	);
+};
+
+export default AnbiamsForm;

--- a/src/features/pious-group/forms/index.ts
+++ b/src/features/pious-group/forms/index.ts
@@ -1,0 +1,5 @@
+export { default as ParishCouncilMembersForm } from './parish-council-members-form';
+export { default as ReligiousParishCouncilMembersForm } from './religious-people-parish-form';
+export { default as PriestNunParishForm } from './priest-nun-parish-form';
+export { default as AnbiamsForm } from './anbiams-form';
+export { default as AnbiamInchargeForm } from './anbiam-incharge-form';

--- a/src/features/pious-group/forms/parish-council-members-form/index.tsx
+++ b/src/features/pious-group/forms/parish-council-members-form/index.tsx
@@ -1,0 +1,152 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+	SingleSelectDropdown,
+	FormButton,
+	CustomFormInput,
+	ControlledDateInputField,
+	TableHeading,
+} from '@/components';
+
+import { electedStatusOptions, positionsOptions, subStationOptions } from '@/forms-options-data';
+import { parishCouncilMemberSchema, type ParishCouncilMemberFormType } from '../../validation';
+
+const ParishCouncilMembersForm = () => {
+	const {
+		control,
+		handleSubmit,
+		formState: { errors },
+	} = useForm<ParishCouncilMemberFormType>({
+		resolver: zodResolver(parishCouncilMemberSchema),
+		defaultValues: {},
+	});
+
+	const onSubmit = (data: ParishCouncilMemberFormType) => {
+		console.warn('Submitted Rent Type:', data);
+	};
+	return (
+		<form onSubmit={handleSubmit(onSubmit)} className="space-y-4 text-sm my-6">
+			<div className="flex flex-wrap w-full gap-4">
+				<div className="flex-1 w-full p-5 space-y-5 border border-gray-300 rounded-md">
+					<TableHeading text="PARTICULARS ABOUT PARISH COUNCIL" className="!ml-0 mb-5 underline" />
+					<SingleSelectDropdown
+						control={control}
+						label="Main-Station"
+						options={subStationOptions}
+						placeholder="Select Sub-Station"
+						name="subStationName"
+						disabled={true}
+						error={errors.subStationName?.message}
+					/>
+					<ControlledDateInputField
+						label="General Election Conducted On"
+						name="electionConductedOn"
+						control={control}
+						placeholder="dd/mm/yyyy"
+						error={errors.electionConductedOn?.message}
+						type="date"
+						disabled={true}
+					/>
+					<ControlledDateInputField
+						label="Period End on"
+						name="periodEndOn"
+						control={control}
+						placeholder="dd/mm/yyyy"
+						error={errors.periodEndOn?.message}
+						type="date"
+					/>
+				</div>
+
+				<div className="flex-1 w-full p-5 space-y-5 border border-gray-300 rounded-md">
+					<TableHeading text="PARTICULARS ABOUT PARISH COUNCIL MEMBERS" className="!ml-0 mb-5 underline" />
+					<SingleSelectDropdown
+						name="position"
+						control={control}
+						label="Position"
+						options={positionsOptions}
+						error={errors.position?.message}
+					/>
+					<SingleSelectDropdown
+						name="electedStatus"
+						control={control}
+						label="Elected Status"
+						options={electedStatusOptions}
+						error={errors.electedStatus?.message}
+					/>
+					<ControlledDateInputField
+						label="Elected Date"
+						name="electedDate"
+						control={control}
+						placeholder="dd/mm/yyyy"
+						error={errors.electedDate?.message}
+						type="date"
+						disabled={true}
+					/>
+					<SingleSelectDropdown
+						control={control}
+						label="Select the Main-Station / Sub-Station"
+						options={subStationOptions}
+						placeholder="Select Sub-Station"
+						name="subStationName"
+						error={errors.subStationName?.message}
+					/>
+					<ControlledDateInputField
+						label="Elected From"
+						name="electedForm"
+						control={control}
+						placeholder="dd/mm/yyyy"
+						error={errors.electedForm?.message}
+						type="date"
+						disabled={true}
+					/>
+					<SingleSelectDropdown
+						control={control}
+						label="Select the Main-Station / Sub-Station"
+						options={subStationOptions}
+						placeholder="Select Sub-Station"
+						name="subStationName"
+						error={errors.subStationName?.message}
+					/>
+					<SingleSelectDropdown
+						control={control}
+						label="Select the Anbiam"
+						options={[]}
+						placeholder="Select Sub-Station"
+						name="selectAnbiam"
+						error={errors.selectAnbiam?.message}
+					/>
+				</div>
+				<div className="flex-1 w-full p-5 space-y-5 border border-gray-300 rounded-md">
+					<TableHeading text="PARTICULARS ABOUT PARISH COUNCIL MEMBERS" className="!ml-0 mb-5 underline" />
+					<SingleSelectDropdown
+						control={control}
+						label="Name of the Person"
+						options={[]}
+						placeholder="Select any one"
+						name="personName"
+						error={errors.personName?.message}
+					/>
+					<CustomFormInput
+						control={control}
+						name="anbiamPostion"
+						label="Position in Anbiam"
+						error={errors.anbiamPostion?.message}
+						placeholder=""
+					/>
+					<CustomFormInput
+						control={control}
+						name="mobileNumber"
+						label="Mobile Number"
+						error={errors.mobileNumber?.message}
+						placeholder=""
+					/>
+				</div>
+			</div>
+			<div className="flex justify-center w-full">
+				<FormButton type="submit" label="Submit" />
+			</div>
+		</form>
+	);
+};
+
+export default ParishCouncilMembersForm;

--- a/src/features/pious-group/forms/parish-council-members-form/index.tsx
+++ b/src/features/pious-group/forms/parish-council-members-form/index.tsx
@@ -34,7 +34,7 @@ const ParishCouncilMembersForm = () => {
 						label="Main-Station"
 						options={subStationOptions}
 						placeholder="Select Sub-Station"
-						name="subStationName"
+						name="mainStationName"
 						disabled={true}
 						error={errors.subStationName?.message}
 					/>
@@ -87,7 +87,7 @@ const ParishCouncilMembersForm = () => {
 						label="Select the Main-Station / Sub-Station"
 						options={subStationOptions}
 						placeholder="Select Sub-Station"
-						name="subStationName"
+						name="memberSubStationName"
 						error={errors.subStationName?.message}
 					/>
 					<ControlledDateInputField
@@ -104,7 +104,7 @@ const ParishCouncilMembersForm = () => {
 						label="Select the Main-Station / Sub-Station"
 						options={subStationOptions}
 						placeholder="Select Sub-Station"
-						name="subStationName"
+						name="councilSubStationName"
 						error={errors.subStationName?.message}
 					/>
 					<SingleSelectDropdown

--- a/src/features/pious-group/forms/priest-nun-parish-form/index.tsx
+++ b/src/features/pious-group/forms/priest-nun-parish-form/index.tsx
@@ -1,0 +1,165 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+	SingleSelectDropdown,
+	FormButton,
+	CustomFormInput,
+	ControlledRadioGroup,
+	ControlledFileUpload,
+} from '@/components';
+import { priestNunParishSchema, type priestNunParishType } from '../../validation';
+
+const PriestNunParishForm = () => {
+	const {
+		control,
+		handleSubmit,
+		formState: { errors },
+	} = useForm<priestNunParishType>({
+		resolver: zodResolver(priestNunParishSchema),
+		defaultValues: {},
+	});
+
+	const onSubmit = (data: priestNunParishType) => {
+		console.warn('Submitted Parish Person:', data);
+	};
+
+	return (
+		<form onSubmit={handleSubmit(onSubmit)} className="space-y-4 text-sm my-6">
+			<div className="flex flex-wrap w-full gap-4">
+				<div className="flex-1 w-full p-5 space-y-5 border border-gray-300 rounded-md">
+					<SingleSelectDropdown
+						control={control}
+						label="Member from Family / Others"
+						options={[{ label: 'SD Convert', value: 'sd_convert' }]}
+						name="institution"
+						error={errors.institution?.message}
+					/>
+					<CustomFormInput
+						control={control}
+						name="personName"
+						label="Name of the Person"
+						error={errors.personName?.message}
+						placeholder="Enter the Religious Person Name"
+					/>
+					<ControlledFileUpload name="image" control={control} label="Image" error={errors.image?.message} />
+
+					<CustomFormInput
+						control={control}
+						name="fatherName"
+						label="Father Name"
+						error={errors.fatherName?.message}
+						placeholder="Enter the Father Name"
+					/>
+					<CustomFormInput
+						control={control}
+						name="motherName"
+						label="Mother Name"
+						error={errors.motherName?.message}
+						placeholder="Enter the Mother Name"
+					/>
+					<SingleSelectDropdown
+						name="gender"
+						control={control}
+						label="Select the Gender"
+						options={[
+							{ label: 'Male', value: 'male' },
+							{ label: 'Female', value: 'female' },
+						]}
+						error={errors.gender?.message}
+					/>
+				</div>
+
+				<div className="flex-1 w-full p-5 space-y-5 border border-gray-300 rounded-md">
+					<SingleSelectDropdown
+						name="dioceseOrCongregation"
+						control={control}
+						label="Diocese / Congregation"
+						options={[
+							{ label: 'Diocese', value: 'diocese' },
+							{ label: 'Congregation', value: 'congregation' },
+						]}
+						error={errors.dioceseOrCongregation?.message}
+					/>
+					<CustomFormInput
+						control={control}
+						name="dioceseName"
+						label="Name of the Diocese"
+						error={errors.dioceseName?.message}
+						placeholder="Enter the Name of the Diocese"
+					/>
+					<SingleSelectDropdown
+						name="brotherhoodOrPriesthood"
+						control={control}
+						label="Brotherhood / Priesthood"
+						options={[
+							{ label: 'Brotherhood', value: 'brotherhood' },
+							{ label: 'Priesthood', value: 'priesthood' },
+						]}
+						error={errors.brotherhoodOrPriesthood?.message}
+					/>
+					<CustomFormInput
+						control={control}
+						name="studying"
+						label="Studying"
+						error={errors.studying?.message}
+						placeholder="Enter Current Study Details"
+					/>
+					<CustomFormInput
+						control={control}
+						name="place"
+						label="Place"
+						error={errors.place?.message}
+						placeholder="Enter the Place"
+					/>
+				</div>
+
+				<div className="flex-1 w-full p-5 space-y-5 border border-gray-300 rounded-md">
+					<CustomFormInput
+						control={control}
+						name="mobileNumber"
+						label="Mobile Number"
+						error={errors.mobileNumber?.message}
+						placeholder="Enter the Mobile Number"
+					/>
+					<CustomFormInput
+						control={control}
+						name="email"
+						label="Email"
+						error={errors.email?.message}
+						placeholder="Enter Email Address"
+					/>
+					<CustomFormInput
+						control={control}
+						name="temporaryAddress"
+						label="Temporary Address"
+						type="textarea"
+						error={errors.temporaryAddress?.message}
+						placeholder="Enter the Temporary Address"
+					/>
+					<ControlledRadioGroup
+						label="Permanent Address"
+						name="permanentAddressStatus"
+						control={control}
+						options={[
+							{ label: 'Same as Temporary Address', value: 'same_as_temporary' },
+							{ label: 'Different Address', value: 'different' },
+						]}
+						error={errors.permanentAddressStatus?.message}
+					/>
+					<CustomFormInput
+						control={control}
+						name="permanentAddress"
+						type="textarea"
+						error={errors.permanentAddress?.message}
+						placeholder="Enter the Permanent Address"
+					/>
+				</div>
+			</div>
+			<div className="flex justify-center w-full">
+				<FormButton type="submit" label="Submit" />
+			</div>
+		</form>
+	);
+};
+
+export default PriestNunParishForm;

--- a/src/features/pious-group/forms/religious-people-parish-form/index.tsx
+++ b/src/features/pious-group/forms/religious-people-parish-form/index.tsx
@@ -39,14 +39,14 @@ const ReligiousParishCouncilMembersForm = () => {
 
 				<div className="flex-1 w-full p-5 space-y-5 border border-gray-300 rounded-md">
 					<SingleSelectDropdown
-						name="position"
+						name="gender"
 						control={control}
 						label="Select the Gender"
 						options={[
 							{ label: 'Male', value: 'male' },
 							{ label: 'Female', value: 'female' },
 						]}
-						error={errors.position?.message}
+						error={errors.gender?.message}
 					/>
 					<SingleSelectDropdown
 						name="position"

--- a/src/features/pious-group/forms/religious-people-parish-form/index.tsx
+++ b/src/features/pious-group/forms/religious-people-parish-form/index.tsx
@@ -1,0 +1,85 @@
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { SingleSelectDropdown, FormButton, CustomFormInput, ControlledFileUpload } from '@/components';
+import { inchargeOptions, positionRoleOptions } from '@/forms-options-data';
+import { religiousPeopleParishSchema, type ReligiousPeopleParishType } from '../../validation';
+
+const ReligiousParishCouncilMembersForm = () => {
+	const {
+		control,
+		handleSubmit,
+		formState: { errors },
+	} = useForm<ReligiousPeopleParishType>({
+		resolver: zodResolver(religiousPeopleParishSchema),
+		defaultValues: {},
+	});
+
+	const onSubmit = (data: ReligiousPeopleParishType) => {
+		console.warn('Submitted Rent Type:', data);
+	};
+	return (
+		<form onSubmit={handleSubmit(onSubmit)} className="space-y-4 text-sm my-6">
+			<div className="flex flex-wrap w-full gap-4">
+				<div className="flex-1 w-full p-5 space-y-5 border border-gray-300 rounded-md">
+					<SingleSelectDropdown
+						control={control}
+						label="Institution/Convent"
+						options={[{ label: 'SD Convert', value: 'sd_convert' }]}
+						name="institution"
+						error={errors.institution?.message}
+					/>
+					<CustomFormInput
+						control={control}
+						name="personName"
+						label="Name of the Religious Person"
+						error={errors.personName?.message}
+						placeholder="Enter the Religious Person Name"
+					/>
+				</div>
+
+				<div className="flex-1 w-full p-5 space-y-5 border border-gray-300 rounded-md">
+					<SingleSelectDropdown
+						name="position"
+						control={control}
+						label="Select the Gender"
+						options={[
+							{ label: 'Male', value: 'male' },
+							{ label: 'Female', value: 'female' },
+						]}
+						error={errors.position?.message}
+					/>
+					<SingleSelectDropdown
+						name="position"
+						control={control}
+						label="Position"
+						options={positionRoleOptions}
+						error={errors.position?.message}
+					/>
+
+					<SingleSelectDropdown
+						control={control}
+						label="Incharge For"
+						options={inchargeOptions}
+						name="incharge"
+						error={errors.incharge?.message}
+					/>
+				</div>
+				<div className="flex-1 w-full p-5 space-y-5 border border-gray-300 rounded-md">
+					<CustomFormInput
+						control={control}
+						name="mobileNumber"
+						label="Mobile Number (Optional)"
+						error={errors.mobileNumber?.message}
+						placeholder="Enter the Mobile Number"
+					/>
+					<ControlledFileUpload name="image" control={control} label="Image" error={errors.image?.message} />
+				</div>
+			</div>
+			<div className="flex justify-center w-full">
+				<FormButton type="submit" label="Submit" />
+			</div>
+		</form>
+	);
+};
+
+export default ReligiousParishCouncilMembersForm;

--- a/src/features/pious-group/pages/pious-group-generic-page/index.tsx
+++ b/src/features/pious-group/pages/pious-group-generic-page/index.tsx
@@ -37,12 +37,14 @@ const PiousGroupGenericPage = () => {
 
 	return (
 		<TabsLayout tabs={tabsData || []} onTabChange={handleToggleTab} activeTabId={activeIndex}>
-			{tabsData?.[activeIndex]?.label === 'view' ? (
+			{tabsData?.[activeIndex]?.label.toLowerCase() === 'view' ? (
 				<RenderPiousGroupTables />
 			) : tabsData?.[activeIndex]?.label.toLowerCase() === 'add' ? (
 				<FormsContainer />
 			) : (
-				<h1>charge</h1>
+				<div className="p-4 text-center text-gray-500">
+					<h2>Feature not available</h2>+ <p>This section is under development.</p>+{' '}
+				</div>
 			)}
 		</TabsLayout>
 	);

--- a/src/features/pious-group/pages/pious-group-generic-page/index.tsx
+++ b/src/features/pious-group/pages/pious-group-generic-page/index.tsx
@@ -3,20 +3,29 @@ import { side_nav_links } from '@/data/side-navbar-content';
 import type { NavLinkProps } from '@/types';
 import { getSectionByPathName } from '@/utils/getSectionByPathName';
 import { useRouteName } from '@/utils/getRouteName';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useStore } from '@/store/store';
-import { RenderPiousGroupOverviewContainer, RenderPiousGroupTables } from '../../components';
+import { FormsContainer, RenderPiousGroupOverviewContainer, RenderPiousGroupTables } from '../../components';
+import { usePathName } from '@/utils/getPathName';
 
 const PiousGroupGenericPage = () => {
-	const [activeIndex, setActiveIndex] = useState(1);
 	const type = useRouteName('type');
+	const pathName = usePathName();
+
 	const { selectRow, selectFamilyCardRow, selectPriorRow } = useStore();
 	const handleToggleTab = (index: number) => {
 		setActiveIndex(index);
 	};
 
-	const linksData = getSectionByPathName(side_nav_links, type as string);
-	const tabsData = linksData?.page_nav_links.find((link: NavLinkProps) => link.path_url === type)?.tabs;
+	const linksData = getSectionByPathName(side_nav_links, pathName);
+	const tabsData = linksData?.page_nav_links.find((link: NavLinkProps) => link.path_url === pathName)?.tabs;
+	const defaultTabIndex = useMemo(() => {
+		if (!tabsData) return 0;
+		const viewIndex = tabsData.findIndex((tab) => tab.label.toLowerCase() === 'view');
+		return viewIndex !== -1 ? viewIndex : 0;
+	}, [tabsData]);
+
+	const [activeIndex, setActiveIndex] = useState(defaultTabIndex);
 
 	if (selectPriorRow) {
 		return <PriorDignitariesContainer />;
@@ -27,12 +36,14 @@ const PiousGroupGenericPage = () => {
 	}
 
 	return (
-		<TabsLayout
-			tabs={tabsData || [{ label: 'view' }, { label: 'add' }]}
-			onTabChange={handleToggleTab}
-			activeTabId={activeIndex}
-		>
-			{activeIndex === 1 && <RenderPiousGroupTables />}
+		<TabsLayout tabs={tabsData || []} onTabChange={handleToggleTab} activeTabId={activeIndex}>
+			{tabsData?.[activeIndex]?.label === 'view' ? (
+				<RenderPiousGroupTables />
+			) : tabsData?.[activeIndex]?.label.toLowerCase() === 'add' ? (
+				<FormsContainer />
+			) : (
+				<h1>charge</h1>
+			)}
 		</TabsLayout>
 	);
 };

--- a/src/features/pious-group/validation/index.ts
+++ b/src/features/pious-group/validation/index.ts
@@ -2,6 +2,9 @@ import { z } from 'zod';
 
 const parishCouncilMemberSchema = z.object({
 	subStationName: z.string().min(1, 'Sub Station is required'),
+	mainStationName: z.string().min(1, 'Main Station is required'),
+	memberSubStationName: z.string().min(1, 'Member Sub Station is required'),
+	councilSubStationName: z.string().min(1, 'Council Sub Station is required'),
 	electionConductedOn: z.string().min(1, 'Election Conducted On is required'),
 	periodEndOn: z.string().min(1, 'Period End On is required'),
 	position: z.enum(['President', 'Secretary', 'Treasurer', 'Caller', 'Member'], {
@@ -23,6 +26,9 @@ const religiousPeopleParishSchema = z.object({
 	position: z.string().min(1, 'Please select a position'),
 	incharge: z.string().min(1, 'Please select an in-charge role'),
 	personName: z.string().min(1, 'Person Name is required'),
+	gender: z.enum(['male', 'female'], {
+		required_error: 'Gender is required',
+	}),
 	mobileNumber: z
 		.string()
 		.regex(/^\d{10}$/, 'Mobile number must be exactly 10 digits')

--- a/src/features/pious-group/validation/index.ts
+++ b/src/features/pious-group/validation/index.ts
@@ -1,0 +1,135 @@
+import { z } from 'zod';
+
+const parishCouncilMemberSchema = z.object({
+	subStationName: z.string().min(1, 'Sub Station is required'),
+	electionConductedOn: z.string().min(1, 'Election Conducted On is required'),
+	periodEndOn: z.string().min(1, 'Period End On is required'),
+	position: z.enum(['President', 'Secretary', 'Treasurer', 'Caller', 'Member'], {
+		required_error: 'Position is required',
+	}),
+	electedStatus: z.string().min(1, 'Please select elected status'),
+	electedDate: z.string().min(1, 'Elected Date is required'),
+	electedForm: z.string().min(1, 'Elected Form is required'),
+	selectAnbiam: z.string().min(1, 'Select Anbiama is required'),
+	personName: z.string().min(1, 'Person Name is required'),
+	mobileNumber: z.string().regex(/^\d{10}$/, 'Mobile number must be exactly 10 digits'),
+	anbiamPostion: z.string().min(1, 'Anbiam Position is required'),
+});
+
+type ParishCouncilMemberFormType = z.infer<typeof parishCouncilMemberSchema>;
+
+const religiousPeopleParishSchema = z.object({
+	institution: z.string().min(1, 'Please select an institution'),
+	position: z.string().min(1, 'Please select a position'),
+	incharge: z.string().min(1, 'Please select an in-charge role'),
+	personName: z.string().min(1, 'Person Name is required'),
+	mobileNumber: z
+		.string()
+		.regex(/^\d{10}$/, 'Mobile number must be exactly 10 digits')
+		.optional()
+		.or(z.literal('')),
+	image: z.custom<File>().refine((file) => file instanceof File && file.size > 0, {
+		message: 'Image file is required',
+	}),
+});
+
+type ReligiousPeopleParishType = z.infer<typeof religiousPeopleParishSchema>;
+
+const priestNunParishSchema = z.object({
+	institution: z.string().min(1, 'Institution is required'),
+	personName: z.string().min(1, 'Name of the Person is required'),
+	fatherName: z.string().min(1, 'Father Name is required'),
+	motherName: z.string().min(1, 'Mother Name is required'),
+
+	gender: z.enum(['male', 'female'], {
+		required_error: 'Gender is required',
+	}),
+
+	dioceseOrCongregation: z.enum(['diocese', 'congregation'], {
+		required_error: 'Please select Diocese or Congregation',
+	}),
+	dioceseName: z.string().min(1, 'Diocese name is required'),
+
+	brotherhoodOrPriesthood: z.enum(['brotherhood', 'priesthood'], {
+		required_error: 'Please select Brotherhood or Priesthood',
+	}),
+
+	studying: z.string().min(1, 'Studying field is required'),
+	place: z.string().min(1, 'Place is required'),
+
+	mobileNumber: z
+		.string()
+		.min(10, 'Mobile number must be at least 10 digits')
+		.max(15, 'Mobile number must be at most 15 digits'),
+
+	email: z.string().email('Enter a valid email address'),
+
+	temporaryAddress: z.string().min(5, 'Temporary address is required'),
+
+	permanentAddressStatus: z.enum(['same_as_temporary', 'different'], {
+		required_error: 'Please choose an address option',
+	}),
+
+	permanentAddress: z.string().min(5, 'Permanent address is required').optional(),
+
+	image: z.custom<File>().refine((file) => file instanceof File && file.size > 0, {
+		message: 'Image file is required',
+	}),
+});
+type priestNunParishType = z.infer<typeof priestNunParishSchema>;
+
+const anbiamsSchema = z.object({
+	parishName: z.string().min(1, 'Parish Name is required'),
+	subStationName: z.string().min(1, 'Sub-Station selection is required'),
+	anbiamName: z.string().min(1, 'Anbiam Name is required'),
+	anbiamShortForm: z.string().min(1, 'Short Form is required'),
+	electedOn: z.string().min(1, 'Election date is required'),
+	periodYears: z
+		.string()
+		.min(1, 'Period is required')
+		.refine((val) => /^\d+$/.test(val), {
+			message: 'Must be a number',
+		}),
+	extendPeriod: z.enum(['yes', 'no'], {
+		required_error: 'Please choose Yes or No',
+	}),
+	periodEndOn: z.string().min(1, 'Period end date is required'),
+});
+
+type AnbiamsType = z.infer<typeof anbiamsSchema>;
+
+const anbiamsInchargeSchema = z.object({
+	subStationName: z.string().min(1, 'Sub-Station is required'),
+	selectedAnbiam: z.string().min(1, 'Anbiam selection is required'),
+	shortForm: z.string().min(1, 'Short form is required'),
+
+	electionConductedOn: z.string().min(1, 'Election conducted date is required'),
+
+	position: z.string().min(1, 'Position is required'),
+	electedStatus: z.enum(['regular', 'intermediate'], {
+		required_error: 'Elected status is required',
+	}),
+	presidentName: z.string().min(1, 'President name is required'),
+	mobileNumber1: z.string().min(10, 'Mobile Number 1 must be at least 10 digits').max(15, 'Too long'),
+	mobileNumber2: z.string().min(10, 'Mobile Number 2 must be at least 10 digits').max(15, 'Too long').optional(),
+
+	electedDate: z.string().min(1, 'Elected Date is required'),
+	periodEndOn: z.string().min(1, 'Period End On is required'),
+});
+type AnbiamInchargeType = z.infer<typeof anbiamsInchargeSchema>;
+
+export {
+	parishCouncilMemberSchema,
+	religiousPeopleParishSchema,
+	priestNunParishSchema,
+	anbiamsSchema,
+	anbiamsInchargeSchema,
+};
+
+export type {
+	ParishCouncilMemberFormType,
+	ReligiousPeopleParishType,
+	priestNunParishType,
+	AnbiamsType,
+	AnbiamInchargeType,
+};

--- a/src/forms-options-data/index.ts
+++ b/src/forms-options-data/index.ts
@@ -206,6 +206,169 @@ const abbreviationOptions = [
 	{ label: 'Others', value: 'Others' },
 ];
 
+const rentTypeOptions = [
+	{ label: 'Rent', value: 'Rent' },
+	{ label: 'Lease', value: 'Lease' },
+];
+
+const shopTypeOptions = [
+	{ label: 'Shop', value: 'Shop' },
+	{ label: 'House', value: 'House' },
+	{ label: 'Community Hall', value: 'Community Hall' },
+	{ label: 'Other', value: 'Other' },
+];
+
+const propertyOwnerOptions = [
+	{ label: 'Parish', value: 'Parish' },
+	{ label: 'Association', value: 'Association' },
+	{ label: 'Diocese', value: 'Diocese' },
+	{ label: 'Other', value: 'Other' },
+];
+
+const maintainedByOptions = [
+	{ label: 'Bishop', value: '0' },
+	{ label: 'Parish Priest', value: '1' },
+	{ label: 'President of the Association', value: '2' },
+	{ label: 'Others', value: '3' },
+];
+
+const maintainedByParishOptions = [
+	{ label: 'Alapakkam Parish', value: 'Alapakkam Parish' },
+	{ label: 'Arakkonam Parish', value: 'Arakkonam Parish' },
+	{ label: 'Arcot Parish (Capuchins)', value: 'Arcot Parish (Capuchins)' },
+	{ label: 'Chengalpattu Parish', value: 'Chengalpattu Parish' },
+	{ label: 'Chitlapakkam Parish', value: 'Chitlapakkam Parish' },
+	{ label: 'Chetpet Parish (Capuchins)', value: 'Chetpet Parish (Capuchins)' },
+	{ label: 'Desur Parish (Jesuits)', value: 'Desur Parish (Jesuits)' },
+	{ label: 'Gandhinagar Parish', value: 'Gandhinagar Parish' },
+	{ label: 'Iruppukuricy Parish', value: 'Iruppukuricy Parish' },
+	{ label: 'Kadambathur Parish', value: 'Kadambathur Parish' },
+	{ label: 'Kancheepuram Parish', value: 'Kancheepuram Parish' },
+	{ label: 'Kilachery Parish', value: 'Kilachery Parish' },
+	{ label: 'Kolappanchery Parish', value: 'Kolappanchery Parish' },
+	{ label: 'Kolathur Parish', value: 'Kolathur Parish' },
+	{ label: 'Kosapet Parish', value: 'Kosapet Parish' },
+	{ label: 'Maduranthagam Parish', value: 'Maduranthagam Parish' },
+	{ label: 'Mandaveli Parish', value: 'Mandaveli Parish' },
+	{ label: 'Manapakkam Parish', value: 'Manapakkam Parish' },
+	{ label: 'Manavalanagar Parish', value: 'Manavalanagar Parish' },
+	{ label: 'Maraimalai Nagar Parish', value: 'Maraimalai Nagar Parish' },
+	{ label: 'Nanmangalam Parish', value: 'Nanmangalam Parish' },
+	{ label: 'Nazarethpet Parish', value: 'Nazarethpet Parish' },
+	{ label: 'Neervalur Parish', value: 'Neervalur Parish' },
+	{ label: 'Nesapakkam Parish', value: 'Nesapakkam Parish' },
+	{ label: 'Padi Parish', value: 'Padi Parish' },
+	{ label: 'Padappai Parish', value: 'Padappai Parish' },
+	{ label: 'Palanchur Parish', value: 'Palanchur Parish' },
+	{ label: 'Palavakkam Parish', value: 'Palavakkam Parish' },
+	{ label: 'Palayaseevaram Parish', value: 'Palayaseevaram Parish' },
+	{ label: 'Pallavaram Parish', value: 'Pallavaram Parish' },
+	{ label: 'Pammal Parish', value: 'Pammal Parish' },
+	{ label: 'Panruti Parish (OFM Cap)', value: 'Panruti Parish (OFM Cap)' },
+	{ label: 'Perungalathur Parish', value: 'Perungalathur Parish' },
+	{ label: 'Perungudi Parish', value: 'Perungudi Parish' },
+	{ label: 'Perur Parish', value: 'Perur Parish' },
+	{ label: 'Poonamallee Parish', value: 'Poonamallee Parish' },
+	{ label: 'Porur Parish', value: 'Porur Parish' },
+	{ label: 'Ramanjeri Parish', value: 'Ramanjeri Parish' },
+	{ label: 'Redhills Parish', value: 'Redhills Parish' },
+	{ label: 'Santhome Cathedral Parish', value: 'Santhome Cathedral Parish' },
+	{ label: 'Sembakkam Parish', value: 'Sembakkam Parish' },
+	{ label: 'Sithalapakkam Parish', value: 'Sithalapakkam Parish' },
+	{ label: 'Sriperumbudur Parish', value: 'Sriperumbudur Parish' },
+	{ label: 'St. Anthony’s Shrine, Broadway Parish', value: 'St. Anthony’s Shrine, Broadway Parish' },
+	{ label: 'St. Joseph’s Shrine, Poonamallee Parish', value: 'St. Joseph’s Shrine, Poonamallee Parish' },
+	{ label: 'St. Mary’s Co-Cathedral Parish, Chennai', value: 'St. Mary’s Co-Cathedral Parish, Chennai' },
+	{ label: 'St. Thomas Mount Parish', value: 'St. Thomas Mount Parish' },
+	{ label: 'Tambaram Parish', value: 'Tambaram Parish' },
+	{ label: 'Thandarai Parish', value: 'Thandarai Parish' },
+	{ label: 'Thiruninravur Parish', value: 'Thiruninravur Parish' },
+	{ label: 'Thiruvallur Parish', value: 'Thiruvallur Parish' },
+	{ label: 'Thiruvanmiyur Parish', value: 'Thiruvanmiyur Parish' },
+	{ label: 'Thiruvotriyur Parish', value: 'Thiruvotriyur Parish' },
+	{ label: 'Thozhupedu Parish', value: 'Thozhupedu Parish' },
+	{ label: 'Tindivanam Parish', value: 'Tindivanam Parish' },
+	{ label: 'Uthiramerur Parish', value: 'Uthiramerur Parish' },
+	{ label: 'Vandavasi Parish', value: 'Vandavasi Parish' },
+	{ label: 'Vellavedu Parish', value: 'Vellavedu Parish' },
+	{ label: 'Villivakkam Parish', value: 'Villivakkam Parish' },
+	{ label: 'Vyasarpadi Parish', value: 'Vyasarpadi Parish' },
+];
+
+const churchInventoryCategoryOptions = [
+	{ label: 'Garments and Vestments', value: 'Garments and Vestments' },
+	{ label: 'Electric Appliances', value: 'Electric Appliances' },
+	{ label: 'Audio Systems', value: 'Audio Systems' },
+	{ label: 'Furniture - Wood Material Based', value: 'Furniture - Wood Material Based' },
+	{ label: 'Furniture - Steel and Iron Based', value: 'Furniture - Steel and Iron Based' },
+	{ label: 'Statue', value: 'Statue' },
+	{ label: 'Instruments', value: 'Instruments' },
+	{ label: 'Glass Items', value: 'Glass Items' },
+	{ label: 'Decoration Things', value: 'Decoration Things' },
+	{ label: 'Others', value: 'Others' },
+];
+
+const buyerTypeOptions = [
+	{ label: 'Purchased', value: 'Purchased' },
+	{ label: 'Sponsored', value: 'Sponsored' },
+];
+
+const ownForOptions = [
+	{ label: 'Parish', value: 'Parish' },
+	{ label: 'Parish Priest', value: 'Parish Priest' },
+	{ label: 'Diocese', value: 'Diocese' },
+];
+const otherInventoryCategoryOptions = [
+	{ label: 'Vehicles', value: '0' },
+	{ label: 'Electric Appliances', value: '1' },
+	{ label: 'Furniture', value: '2' },
+	{ label: 'Home Appliances', value: '3' },
+	{ label: 'Furniture - Steel and Iron Based', value: '4' },
+	{ label: 'Kitchen Accessories', value: '5' },
+	{ label: 'Others', value: '6' },
+];
+
+const positionsOptions = [
+	{ label: 'President', value: 'President' },
+	{ label: 'Secretary', value: 'Secretary' },
+	{ label: 'Treasurer', value: 'Treasurer' },
+	{ label: 'Caller', value: 'Caller' },
+	{ label: 'Member', value: 'Member' },
+];
+
+const electedStatusOptions = [
+	{ label: 'Regular', value: 'Regular' },
+	{ label: 'Intermediate', value: 'Intermediate' },
+];
+
+const positionRoleOptions = [
+	{ label: 'Asst.PP', value: 'Asst.PP' },
+	{ label: 'Fr', value: 'Fr' },
+	{ label: 'Sup', value: 'Sup' },
+	{ label: 'Sr', value: 'Sr' },
+	{ label: 'Br', value: 'Br' },
+	{ label: 'Dn', value: 'Dn' },
+	{ label: 'Rec', value: 'Rec' },
+	{ label: 'Nurse', value: 'Nurse' },
+	{ label: 'Teacher', value: 'Teacher' },
+	{ label: 'Choir Master', value: 'Choir Master' },
+	{ label: 'Studying', value: 'Studying' },
+	{ label: 'Other', value: 'Other' },
+];
+const inchargeOptions = [
+	{ label: 'Choir', value: 'Choir' },
+	{ label: 'Liturgy', value: 'Liturgy' },
+	{ label: 'Dispensary', value: 'Dispensary' },
+	{ label: 'Social Service', value: 'Social Service' },
+	{ label: 'Ministry', value: 'Ministry' },
+	{ label: 'Records', value: 'Records' },
+	{ label: 'Financial', value: 'Financial' },
+	{ label: 'Hospital', value: 'Hospital' },
+	{ label: 'School', value: 'School' },
+	{ label: 'Catism', value: 'Catism' },
+	{ label: 'Other', value: 'Other' },
+];
+
 export {
 	categoryOptions,
 	schoolTypeOptions,
@@ -223,4 +386,17 @@ export {
 	conventTypeOptions,
 	congregationOptions,
 	abbreviationOptions,
+	rentTypeOptions,
+	shopTypeOptions,
+	propertyOwnerOptions,
+	maintainedByOptions,
+	maintainedByParishOptions,
+	churchInventoryCategoryOptions,
+	buyerTypeOptions,
+	ownForOptions,
+	otherInventoryCategoryOptions,
+	positionsOptions,
+	electedStatusOptions,
+	positionRoleOptions,
+	inchargeOptions,
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced multiple new forms for managing parish council members, religious people, priests/nuns, Anbiams, and Anbiam incharge, each with validation and error handling.
  * Added a centralized container to render the appropriate form based on selected navigation.
  * Implemented file upload support within forms.
  * Expanded available dropdown options for various form fields.
  * Added new navigation tabs and standardized tab labels for improved consistency.
  * Added a controlled file upload component integrated with form state management.

* **Enhancements**
  * Improved tab navigation logic and default tab selection on the Pious Group page.
  * Updated styling for textarea components for a more consistent appearance.
  * Made form input labels optional for greater flexibility.

* **Bug Fixes**
  * Standardized and fixed inconsistencies in navigation tab labels.

* **Documentation**
  * Centralized and re-exported form components and options for easier imports and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->